### PR TITLE
fix: handle account for sequence 0

### DIFF
--- a/lib/components/TxDialog/index.vue
+++ b/lib/components/TxDialog/index.vue
@@ -141,8 +141,12 @@ async function initData() {
         view.value = 'input';
         p.value = JSON.parse(props.params || '{}');
         getAccountInfo(props.endpoint, props.sender).then((res) => {
-            if (!res.info?.pub_key) return;
-            memo.value = `did:hp:${base64ToHex(res.info.pub_key.key)}`;
+            if (!res.info?.pub_key) {
+                memo.value = 'did on board';
+            }
+            else {
+                memo.value = `did:hp:${base64ToHex(res.info.pub_key.key)}`;
+            }
         });
         const fee = convert.baseToUnit(p.value?.fees || { amount: '1', denom: 'hp' }, 'hp') // 1HP for default fee
         feeAmount.value = Number(fee.amount);

--- a/lib/components/TxDialog/index.vue
+++ b/lib/components/TxDialog/index.vue
@@ -141,6 +141,7 @@ async function initData() {
         view.value = 'input';
         p.value = JSON.parse(props.params || '{}');
         getAccountInfo(props.endpoint, props.sender).then((res) => {
+            if (!res.info?.pub_key) return;
             memo.value = `did:hp:${base64ToHex(res.info.pub_key.key)}`;
         });
         const fee = convert.baseToUnit(p.value?.fees || { amount: '1', denom: 'hp' }, 'hp') // 1HP for default fee


### PR DESCRIPTION
when the account did not initiate any transaction, the node do not knows the account's pubKey. 
handle that case, so that there is no side effect(initializing parameters)